### PR TITLE
Added an erase.sh script that will erase the Sonoff's flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ By default the Sonoff will have a Enabled state at power on, you can change this
 
 Done! 🎉 
 
+## Troubleshooting
+
+If the Captive Portal does not close after inserting your WiFi password (and also doesn't connect to your WiFi) then you can run the `erase.sh` script, which will completely erase your Sonoff's flash. After running `erase.sh` you should reflash the Sonoff by following the normal installation instructions. This will most likely solve the issue.
+
 ## If you like this project please:
 
 <a href="https://bmc.xyz/l/SonoffHomekit" target="_blank"><img src="https://raw.githubusercontent.com/Gruppio/Sonoff-Homekit/images/images/buymeacoffee.png" alt="Buy Me A Coffee" width="300" ></a>

--- a/erase.sh
+++ b/erase.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+SONOFF_PORT="/dev/cu.wchusbserial14310"
+
+esptool.py \
+            -p $SONOFF_PORT \
+            --baud 115200 \
+            erase_flash


### PR DESCRIPTION
I encountered some issues while connecting the Sonoff to my WiFi using the captive portal. The captive portal would not close and the Sonoff would not connect to my WiFi. After reading this very helpful comment: https://github.com/Gruppio/Sonoff-Homekit/pull/3#issuecomment-465571317 I managed to solve the issue by erasing the Sonoff's flash before flashing the firmware.

I have added a little helper script and updated the README on how to solve this issue should you encounter it.